### PR TITLE
資料と課題の説明を表示する部分の処理の不具合修正

### DIFF
--- a/views/main.py
+++ b/views/main.py
@@ -422,6 +422,8 @@ class Events(BaseEvents):
 		self.parent.showannouncements(self.courseId)
 		self.parent.announcementCreateButton()
 		self.parent.description_data()
+		self.parent.DSCBOX.Clear()
+		self.parent.DSCBOX.Disable()
 		materials = self.parent.tempFiles(self.courseId)
 		materials = self.parent.workMaterials(materials)
 		self.parent.creator.GetPanel().Layout()
@@ -445,8 +447,6 @@ class Events(BaseEvents):
 	def onWorkSelected(self, event):
 		description = self.parent.tree.GetItemData(self.parent.tree.GetFocusedItem())
 		if description == None:
-			self.parent.DSCBOX.Clear()
-			self.parent.DSCBOX.Disable()
 			return
 		if "description" in description:
 			self.parent.DSCBOX.Enable()


### PR DESCRIPTION
1.資料をトピックありとなしに分けて表示できるようにした。
2.課題やおしらすぉ読み込んだときに空欄の説明欄が表示されていたので、関数が実行されるタイミングで無効にしてしまうように修正。